### PR TITLE
Added support for SSL over TCP for registry and request related connections

### DIFF
--- a/vyked/bus.py
+++ b/vyked/bus.py
@@ -127,8 +127,10 @@ class TCPBus:
             raise ClientNotFoundError()
 
     def _connect_to_client(self, host, node_id, port, service_type, service_client):
+
         future = asyncio.async(
-            asyncio.get_event_loop().create_connection(partial(get_vyked_protocol, service_client), host, port))
+            asyncio.get_event_loop().create_connection(partial(get_vyked_protocol, service_client), host, port,
+                                                       ssl=service_client._ssl_context))
         future.add_done_callback(
             partial(self._service_client_connection_callback, self._node_clients[node_id], node_id, service_type))
         return future
@@ -227,11 +229,12 @@ class TCPBus:
 class PubSubBus:
     PUBSUB_DELAY = 5
 
-    def __init__(self, registry_client):
+    def __init__(self, registry_client, ssl_context= None):
         self._pubsub_handler = None
         self._registry_client = registry_client
         self._clients = None
         self._pending_publishes = {}
+        self._ssl_context = ssl_context
 
     def create_pubsub_handler(self, host, port):
         self._pubsub_handler = PubSub(host, port)

--- a/vyked/host.py
+++ b/vyked/host.py
@@ -25,6 +25,7 @@ class Host:
     _host_id = None
     _tcp_service = None
     _http_service = None
+    registry_client_ssl = None
 
     @classmethod
     def _set_process_name(cls):
@@ -39,13 +40,14 @@ class Host:
 
     @classmethod
     def attach_service(cls, service):
-        cls._set_bus(service)
         if isinstance(service, HTTPService):
             cls._http_service = service
         elif isinstance(service, TCPService):
             cls._tcp_service = service
         else:
             _logger.error('Invalid argument attached as service')
+        cls._set_bus(service)
+
 
     @classmethod
     def run(cls):
@@ -66,9 +68,10 @@ class Host:
     @classmethod
     def _create_tcp_server(cls):
         if cls._tcp_service:
+            ssl_context = cls._tcp_service.ssl_context
             host_ip, host_port = cls._tcp_service.socket_address
             task = asyncio.get_event_loop().create_server(partial(get_vyked_protocol, cls._tcp_service.tcp_bus),
-                                                          host_ip, host_port)
+                                                          host_ip, host_port, ssl= ssl_context)
             result = asyncio.get_event_loop().run_until_complete(task)
             return result
 
@@ -152,10 +155,12 @@ class Host:
 
     @classmethod
     def _set_bus(cls, service):
-        registry_client = RegistryClient(asyncio.get_event_loop(), cls.registry_host, cls.registry_port)
+        registry_client = RegistryClient(asyncio.get_event_loop(), cls.registry_host, cls.registry_port, cls.registry_client_ssl)
         tcp_bus = TCPBus(registry_client)
         registry_client.conn_handler = tcp_bus
-        pubsub_bus = PubSubBus(registry_client)
+        pubsub_bus = PubSubBus(registry_client, ssl_context=cls._tcp_service._ssl_context)
+        #pubsub_bus = PubSubBus(registry_client)#, cls._tcp_service._ssl_context)
+
         registry_client.bus = tcp_bus
         if isinstance(service, TCPService):
             tcp_bus.tcp_host = service

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -141,7 +141,6 @@ class Repository:
 class Registry:
 
     def __init__(self, ip, port, repository: Repository):
-        config = json_file_to_dict('./config.json')
         self._ip = ip
         self._port = port
         self._loop = asyncio.get_event_loop()
@@ -150,6 +149,7 @@ class Registry:
         self._repository = repository
         self._pingers = {}
         try:
+            config = json_file_to_dict('./config.json')
             self._ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             self._ssl_context.load_cert_chain(config['SSL_CERTIFICATE'], config['SSL_KEY'])
         except:

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -12,6 +12,9 @@ from .protocol_factory import get_vyked_protocol
 from .pinger import TCPPinger, HTTPPinger
 from .utils.log import setup_logging
 
+import json
+import ssl
+
 Service = namedtuple('Service', ['name', 'version', 'dependencies', 'host', 'port', 'node_id', 'type'])
 logger = logging.getLogger(__name__)
 
@@ -19,6 +22,12 @@ logger = logging.getLogger(__name__)
 def tree():
     return defaultdict(tree)
 
+def json_file_to_dict(_file: str) -> dict:
+    config = None
+    with open(_file) as config_file:
+        config = json.load(config_file)
+
+    return config
 
 class Repository:
 
@@ -132,6 +141,7 @@ class Repository:
 class Registry:
 
     def __init__(self, ip, port, repository: Repository):
+        config = json_file_to_dict('./config.json')
         self._ip = ip
         self._port = port
         self._loop = asyncio.get_event_loop()
@@ -139,12 +149,17 @@ class Registry:
         self._service_protocols = {}
         self._repository = repository
         self._pingers = {}
+        try:
+            self._ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            self._ssl_context.load_cert_chain(config['SSL_CERTIFICATE'], config['SSL_KEY'])
+        except:
+            self._ssl_context = None
 
     def start(self):
         setup_logging("registry")
         self._loop.add_signal_handler(getattr(signal, 'SIGINT'), partial(self._stop, 'SIGINT'))
         self._loop.add_signal_handler(getattr(signal, 'SIGTERM'), partial(self._stop, 'SIGTERM'))
-        registry_coroutine = self._loop.create_server(partial(get_vyked_protocol, self), self._ip, self._port)
+        registry_coroutine = self._loop.create_server(partial(get_vyked_protocol, self), self._ip, self._port, ssl=self._ssl_context)
         server = self._loop.run_until_complete(registry_coroutine)
         try:
             self._loop.run_forever()

--- a/vyked/registry_client.py
+++ b/vyked/registry_client.py
@@ -24,7 +24,7 @@ def _retry_for_exception(_):
 class RegistryClient:
     logger = logging.getLogger(__name__)
 
-    def __init__(self, loop, host, port):
+    def __init__(self, loop, host, port, ssl_context=None):
         self._loop = loop
         self._port = port
         self._host = host
@@ -38,6 +38,7 @@ class RegistryClient:
         self._pending_requests = {}
         self._available_services = defaultdict(list)
         self._assigned_services = defaultdict(lambda: defaultdict(list))
+        self._ssl_context = ssl_context
 
     @property
     def conn_handler(self):
@@ -77,7 +78,7 @@ class RegistryClient:
            strategy=[0, 2, 4, 8, 16, 32])
     def connect(self):
         self._transport, self._protocol = yield from self._loop.create_connection(partial(get_vyked_protocol, self),
-                                                                                  self._host, self._port)
+                                                                                  self._host, self._port, ssl=self._ssl_context)
         self.conn_handler.handle_connected()
         self._pinger = TCPPinger('registry', self._protocol, self)
         self._pinger.ping()

--- a/vyked/services.py
+++ b/vyked/services.py
@@ -48,10 +48,15 @@ class _Service:
 class TCPServiceClient(_Service):
     REQUEST_TIMEOUT_SECS = 600
 
-    def __init__(self, service_name, service_version):
+    def __init__(self, service_name, service_version, ssl_context=None):
         super(TCPServiceClient, self).__init__(service_name, service_version)
         self._pending_requests = {}
         self.tcp_bus = None
+        self._ssl_context = ssl_context
+
+    @property
+    def ssl_context(self):
+        return self._ssl_context
 
     def _send_request(self, app_name, endpoint, entity, params):
         packet = MessagePacket.request(self.name, self.version, app_name, _Service._REQ_PKT_STR, endpoint, params,
@@ -176,8 +181,12 @@ class _ServiceHost(_Service):
 
 
 class TCPService(_ServiceHost):
-    def __init__(self, service_name, service_version, host_ip=None, host_port=None):
+    def __init__(self, service_name, service_version, host_ip=None, host_port=None, ssl_context=None):
         super(TCPService, self).__init__(service_name, service_version, host_ip, host_port)
+        self._ssl_context = ssl_context
+    @property
+    def ssl_context(self):
+        return self._ssl_context
 
     def _publish(self, endpoint, payload):
         self._pubsub_bus.publish(self.name, self.version, endpoint, payload)


### PR DESCRIPTION
Registry reads path to certificate/key file from config.json. TCP service/clients take additional parameter ssl_context as input. Host requires setting up Host.registry_client_ssl to ssl_context to connect to Registry.
