### PR TITLE
Fix for issue#90, pending_requests now pops completed requests

### DIFF
--- a/vyked/registry_client.py
+++ b/vyked/registry_client.py
@@ -176,11 +176,11 @@ class RegistryClient:
 
     def _handle_subscriber_packet(self, packet):
         request_id = packet['request_id']
-        future = self._pending_requests[request_id]
+        future = self._pending_requests.pop(request_id, None)
         future.set_result(packet['params']['subscribers'])
 
     def _handle_get_instances(self, packet):
-        future = self._pending_requests[packet['request_id']]
+        future = self._pending_requests.pop(packet['request_id'], None)
         future.set_result(packet['params']['instances'])
 
     def _handle_new_instance(self, service, version, host, port, node, type):


### PR DESCRIPTION
pending_requests in registry_client no longer grows unchecked #90
