### PR TITLE
Issue 93 fix

### DIFF
--- a/vyked/packet.py
+++ b/vyked/packet.py
@@ -16,15 +16,21 @@ class _Packet:
         return {'pid': cls._next_pid(), 'type': 'ack', 'request_id': request_id}
 
     @classmethod
-    def pong(cls, node_id):
+    def pong(cls, node_id, payload=None):
+        if payload:
+            return cls._get_ping_pong(node_id, 'ping', payload=payload)
         return cls._get_ping_pong(node_id, 'pong')
 
     @classmethod
-    def ping(cls, node_id):
+    def ping(cls, node_id, payload=None):
+        if payload:
+            return cls._get_ping_pong(node_id, 'ping', payload=payload)
         return cls._get_ping_pong(node_id, 'ping')
 
     @classmethod
-    def _get_ping_pong(cls, node_id, packet_type):
+    def _get_ping_pong(cls, node_id, packet_type, payload=None):
+        if payload:
+            return {'pid': cls._next_pid(), 'type': packet_type, 'node_id': node_id, 'payload': payload}
         return {'pid': cls._next_pid(), 'type': packet_type, 'node_id': node_id}
 
 

--- a/vyked/pinger.py
+++ b/vyked/pinger.py
@@ -15,7 +15,7 @@ class Pinger:
     Pinger to send ping packets to an endpoint and inform if the timeout has occurred
     """
 
-    def __init__(self, handler, interval, timeout, loop=asyncio.get_event_loop(), max_failures=2):
+    def __init__(self, handler, interval, timeout, loop=asyncio.get_event_loop(), max_failures=5):
         """
         Aysncio based pinger
         :param handler: Pinger uses it to send a ping and inform when timeout occurs.

--- a/vyked/pinger.py
+++ b/vyked/pinger.py
@@ -98,21 +98,21 @@ class HTTPPinger:
         self._handler = handler
         self._url = 'http://{}:{}/ping'.format(host, port)
 
-    def ping(self):
+    def ping(self, payload=None):
         asyncio.async(self._pinger.send_ping())
 
-    def send_ping(self):
+    def send_ping(self, payload=None):
         asyncio.async(self.ping_coroutine())
 
-    def ping_coroutine(self):
+    def ping_coroutine(self, payload=None):
         res = yield from request('get', self._url)
         if res.status == 200:
             self.pong_received()
             res.close()
 
-    def on_timeout(self):
+    def on_timeout(self, payload=None):
         self.logger.debug('Node %s timed out', self._node_id)
         self._handler.on_timeout(self._node_id)
 
-    def pong_received(self):
+    def pong_received(self, payload=None):
         self._pinger.pong_received()

--- a/vyked/pinger.py
+++ b/vyked/pinger.py
@@ -32,12 +32,12 @@ class Pinger:
         self._max_failures = max_failures
 
     @asyncio.coroutine
-    def send_ping(self):
+    def send_ping(self, payload=None):
         """
         Sends the ping after the interval specified when initializing
         """
         yield from asyncio.sleep(self._interval)
-        self._handler.send_ping()
+        self._handler.send_ping(payload=payload)
         self._start_timer()
 
     def pong_received(self):

--- a/vyked/pinger.py
+++ b/vyked/pinger.py
@@ -40,13 +40,13 @@ class Pinger:
         self._handler.send_ping(payload=payload)
         self._start_timer()
 
-    def pong_received(self):
+    def pong_received(self, payload=None):
         """
         Called when a pong is received. So the timer is cancelled
         """
         self._timer.cancel()
         self._failures = 0
-        asyncio.async(self.send_ping())
+        asyncio.async(self.send_ping(payload=payload))
 
     def _start_timer(self):
         self._timer = self._loop.call_later(self._timeout, self._on_timeout)
@@ -79,8 +79,8 @@ class TCPPinger:
         self.logger.debug('Node %s timed out', self._node_id)
         self._handler.on_timeout(self._node_id)
 
-    def pong_received(self):
-        self._pinger.pong_received()
+    def pong_received(self, payload=None):
+        self._pinger.pong_received(payload=payload)
 
 
 class HTTPPinger:

--- a/vyked/pinger.py
+++ b/vyked/pinger.py
@@ -69,11 +69,11 @@ class TCPPinger:
         self._protocol = protocol
         self._handler = handler
 
-    def ping(self):
-        asyncio.async(self._pinger.send_ping())
+    def ping(self, payload=None):
+        asyncio.async(self._pinger.send_ping(payload=payload))
 
-    def send_ping(self):
-        self._protocol.send(ControlPacket.ping(self._node_id))
+    def send_ping(self, payload=None):
+        self._protocol.send(ControlPacket.ping(self._node_id, payload=payload))
 
     def on_timeout(self):
         self.logger.debug('Node %s timed out', self._node_id)

--- a/vyked/pinger.py
+++ b/vyked/pinger.py
@@ -99,20 +99,20 @@ class HTTPPinger:
         self._url = 'http://{}:{}/ping'.format(host, port)
 
     def ping(self, payload=None):
-        asyncio.async(self._pinger.send_ping())
+        asyncio.async(self._pinger.send_ping(payload=payload))
 
     def send_ping(self, payload=None):
-        asyncio.async(self.ping_coroutine())
+        asyncio.async(self.ping_coroutine(payload=payload))
 
     def ping_coroutine(self, payload=None):
         res = yield from request('get', self._url)
         if res.status == 200:
-            self.pong_received()
+            self.pong_received(payload=payload)
             res.close()
 
-    def on_timeout(self, payload=None):
+    def on_timeout(self):
         self.logger.debug('Node %s timed out', self._node_id)
         self._handler.on_timeout(self._node_id)
 
     def pong_received(self, payload=None):
-        self._pinger.pong_received()
+        self._pinger.pong_received(payload=payload)

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -214,7 +214,17 @@ class Registry:
         elif request_type == 'pong':
             self._ping(packet)
         elif request_type == 'ping':
-            self._pong(packet, protocol)
+            if 'payload' in packet:
+                to_send=True
+                node_ids = list(packet['payload'].values())
+                for node_id in node_ids:
+                    if self._repository.get_node(node_id) is None:
+                        to_send = False
+                        break
+                if to_send:
+                    self._pong(packet, protocol)
+            else:
+                self._pong(packet, protocol)
         elif request_type == 'uptime_report':
             self._get_uptime_report(packet, protocol)
 

--- a/vyked/registry_client.py
+++ b/vyked/registry_client.py
@@ -33,7 +33,7 @@ class RegistryClient:
         self._protocol = None
         self._service = None
         self._version = None
-        self._node_ids = None
+        self._node_ids = {}
         self._pinger = None
         self._conn_handler = None
         self._pending_requests = {}

--- a/vyked/registry_client.py
+++ b/vyked/registry_client.py
@@ -102,7 +102,7 @@ class RegistryClient:
         elif packet['type'] == 'subscribers':
             self._handle_subscriber_packet(packet)
         elif packet['type'] == 'pong':
-            self._pinger.pong_received()
+            self._pinger.pong_received(payload=self._node_ids)
         elif packet['type'] == 'instances':
             self._handle_get_instances(packet)
 

--- a/vyked/registry_client.py
+++ b/vyked/registry_client.py
@@ -33,6 +33,7 @@ class RegistryClient:
         self._protocol = None
         self._service = None
         self._version = None
+        self._node_ids = None
         self._pinger = None
         self._conn_handler = None
         self._pending_requests = {}
@@ -51,6 +52,7 @@ class RegistryClient:
     def register(self, ip, port, service, version, node_id, vendors, service_type):
         self._service = service
         self._version = version
+        self._node_ids[service_type] = node_id
         packet = ControlPacket.registration(ip, port, node_id, service, version, vendors, service_type)
         self._protocol.send(packet)
 
@@ -81,7 +83,7 @@ class RegistryClient:
                                                                                   self._host, self._port, ssl=self._ssl_context)
         yield from self.conn_handler.handle_connected()
         self._pinger = TCPPinger('registry', self._protocol, self)
-        self._pinger.ping()
+        self._pinger.ping(payload=self._node_ids)
         return self._transport, self._protocol
 
     def on_timeout(self, node_id):


### PR DESCRIPTION
fix for issue #93.
Now registry only responds to pings from registry_client if the services are registered. 
Registry will not respond if either TCP or HTTP service is de-registered.

The absence of ping responses would prompt registry_client to re-register its services.
