### PR TITLE
Close TCP Pinger connection on time-out

### DIFF
--- a/vyked/__init__.py
+++ b/vyked/__init__.py
@@ -13,4 +13,4 @@ from .exceptions import RequestException, VykedServiceError, VykedServiceExcepti
 from .utils.log import setup_logging, config_logs
 from .wrappers import Response, Request
 
-__version__ = '2.1.58'
+__version__ = '2.1.59'

--- a/vyked/__init__.py
+++ b/vyked/__init__.py
@@ -13,4 +13,4 @@ from .exceptions import RequestException, VykedServiceError, VykedServiceExcepti
 from .utils.log import setup_logging, config_logs
 from .wrappers import Response, Request
 
-__version__ = '2.1.63'
+__version__ = '2.1.64'

--- a/vyked/__init__.py
+++ b/vyked/__init__.py
@@ -13,4 +13,4 @@ from .exceptions import RequestException, VykedServiceError, VykedServiceExcepti
 from .utils.log import setup_logging, config_logs
 from .wrappers import Response, Request
 
-__version__ = '2.1.62'
+__version__ = '2.1.63'

--- a/vyked/__init__.py
+++ b/vyked/__init__.py
@@ -13,4 +13,4 @@ from .exceptions import RequestException, VykedServiceError, VykedServiceExcepti
 from .utils.log import setup_logging, config_logs
 from .wrappers import Response, Request
 
-__version__ = '2.1.60'
+__version__ = '2.1.61'

--- a/vyked/__init__.py
+++ b/vyked/__init__.py
@@ -13,4 +13,4 @@ from .exceptions import RequestException, VykedServiceError, VykedServiceExcepti
 from .utils.log import setup_logging, config_logs
 from .wrappers import Response, Request
 
-__version__ = '2.1.61'
+__version__ = '2.1.62'

--- a/vyked/__init__.py
+++ b/vyked/__init__.py
@@ -13,4 +13,4 @@ from .exceptions import RequestException, VykedServiceError, VykedServiceExcepti
 from .utils.log import setup_logging, config_logs
 from .wrappers import Response, Request
 
-__version__ = '2.1.59'
+__version__ = '2.1.60'

--- a/vyked/decorators/http.py
+++ b/vyked/decorators/http.py
@@ -1,6 +1,7 @@
 from asyncio import iscoroutine, coroutine, wait_for, TimeoutError
 from functools import wraps
-from vyked import HTTPServiceClient, HTTPService, VykedServiceException
+from vyked import HTTPServiceClient, HTTPService
+from ..exceptions import VykedServiceException
 from aiohttp.web import Response
 from ..utils.stats import Stats
 import logging

--- a/vyked/decorators/http.py
+++ b/vyked/decorators/http.py
@@ -1,6 +1,6 @@
 from asyncio import iscoroutine, coroutine, wait_for, TimeoutError
 from functools import wraps
-from vyked import HTTPServiceClient, HTTPService
+from vyked import HTTPServiceClient, HTTPService, VykedServiceException
 from aiohttp.web import Response
 from ..utils.stats import Stats
 import logging
@@ -47,12 +47,21 @@ def get_decorated_fun(method, path, required_params):
                     wrapped_func = coroutine(func)
                 try:
                     result = yield from wait_for(wrapped_func(self, *args, **kwargs), 120)
+
                 except TimeoutError as e:
                     Stats.http_stats['timedout'] += 1
                     logging.error("HTTP request had a %s" % str(e))
-                except BaseException as e:
-                    Stats.http_stats['total_errors'] += 1
+
+                except VykedServiceException as e:
+                    Stats.http_stats['total_responses'] += 1
+                    _logger.error(str(e))
                     raise e
+
+                except Exception as e:
+                    Stats.http_stats['total_errors'] += 1
+                    _logger.exception('api request exception')
+                    raise e
+
                 else:
                     t2 = time.time()
                     hostname = socket.gethostname()
@@ -66,7 +75,7 @@ def get_decorated_fun(method, path, required_params):
                     }
                     logging.getLogger('stats').info(logd)
                     Stats.http_stats['total_responses'] += 1
-                    return (result)
+                    return result
 
         f.is_http_method = True
         f.method = method

--- a/vyked/decorators/tcp.py
+++ b/vyked/decorators/tcp.py
@@ -160,7 +160,7 @@ def _get_api_decorator(func=None, old_api=None, replacement_api=None):
         }
         logging.getLogger('stats').info(logd)
         _logger.debug('Time taken for %s is %d milliseconds', func.__name__, end_time - start_time)
-        if not (old_api):
+        if not old_api:
             return self._make_response_packet(request_id=rid, from_id=from_id, entity=entity, result=result,
                                               error=error)
         else:

--- a/vyked/pinger.py
+++ b/vyked/pinger.py
@@ -76,7 +76,6 @@ class TCPPinger:
         self._protocol.send(ControlPacket.ping(self._node_id))
 
     def on_timeout(self):
-        self.logger.debug('Node %s timed out', self._node_id)
         self._handler.on_timeout(self._node_id)
 
     def pong_received(self):
@@ -106,7 +105,6 @@ class HTTPPinger:
             res.close()
 
     def on_timeout(self):
-        self.logger.debug('Node %s timed out', self._node_id)
         self._handler.on_timeout(self._node_id)
 
     def pong_received(self):

--- a/vyked/pinger.py
+++ b/vyked/pinger.py
@@ -77,6 +77,7 @@ class TCPPinger:
 
     def on_timeout(self):
         self.logger.debug('Node %s timed out', self._node_id)
+        self._protocol.close()
         self._handler.on_timeout(self._node_id)
 
     def pong_received(self):

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -111,6 +111,7 @@ class Repository:
             for host, uptimes in nodes.items():
                 if host == thehost and uptimes['node_id'] == node_id:
                     uptimes['downtime'] = int(time.time())
+                    self.log_uptimes()
         return None
 
     def get_uptimes(self):

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -32,7 +32,6 @@ def json_file_to_dict(_file: str) -> dict:
 
 
 class Repository:
-
     def __init__(self):
         self._registered_services = defaultdict(lambda: defaultdict(list))
         self._pending_services = defaultdict(list)
@@ -158,7 +157,6 @@ class Repository:
 
 
 class Registry:
-
     def __init__(self, ip, port, repository: Repository):
         self._ip = ip
         self._port = port
@@ -220,21 +218,20 @@ class Registry:
 
     def deregister_service(self, node_id):
         service = self._repository.get_node(node_id)
-        for_log = {}
-        for_log["caller_name"] = service.name + '/' + service.version
-        for_log["caller_address"] = service.host
-        for_log["request_type"] = 'deregister'
-        logger.debug(for_log)
-        self._repository.remove_node(node_id)
-        if service is not None:
-            self._service_protocols.pop(node_id, None)
-            self._client_protocols.pop(node_id, None)
-            self._notify_consumers(service.name, service.version, node_id)
-            if not len(self._repository.get_instances(service.name, service.version)):
-                consumers = self._repository.get_consumers(service.name, service.version)
-                for consumer_name, consumer_version in consumers:
-                    for _, _, node_id, _ in self._repository.get_instances(consumer_name, consumer_version):
-                        self._repository.add_pending_service(consumer_name, consumer_version, node_id)
+        if service:
+            for_log = {"caller_name": service.name + '/' + service.version, "caller_address": service.host,
+                       "request_type": 'deregister'}
+            logger.debug(for_log)
+            self._repository.remove_node(node_id)
+            if service is not None:
+                self._service_protocols.pop(node_id, None)
+                self._client_protocols.pop(node_id, None)
+                self._notify_consumers(service.name, service.version, node_id)
+                if not len(self._repository.get_instances(service.name, service.version)):
+                    consumers = self._repository.get_consumers(service.name, service.version)
+                    for consumer_name, consumer_version in consumers:
+                        for _, _, node_id, _ in self._repository.get_instances(consumer_name, consumer_version):
+                            self._repository.add_pending_service(consumer_name, consumer_version, node_id)
 
     def register_service(self, packet: dict, registry_protocol):
         params = packet['params']

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -327,6 +327,8 @@ class Registry:
         protocol.send(packet)
 
     def on_timeout(self, node_id):
+        service = self._repository.get_node(node_id)
+        logger.debug('%s timed out', service)
         self.deregister_service(node_id)
 
     def _ping(self, packet):

--- a/vyked/services.py
+++ b/vyked/services.py
@@ -68,8 +68,8 @@ class TCPServiceClient(_Service):
             self.tcp_bus.send(packet)
         except ClientException as e:
             if not future.done() and not future.cancelled():
-                ERROR = '101_Client not found'
-                exception = RequestException(ERROR)
+                ERROR = 'Client not found'
+                exception = ClientException(ERROR)
                 exception.error = ERROR
                 future.set_exception(exception)
         _Service.time_future(future, TCPServiceClient.REQUEST_TIMEOUT_SECS)

--- a/vyked/utils/log.py
+++ b/vyked/utils/log.py
@@ -1,5 +1,5 @@
 from logging import Handler
-from logging.handlers import RotatingFileHandler
+from logging import FileHandler
 from queue import Queue
 import sys
 import os
@@ -113,18 +113,18 @@ def setup_logging(identifier):
     stream_handler.setFormatter(formatter)
     logger.addHandler(stream_handler)
     logfile = os.path.join(LOGS_DIR, LOG_FILE_NAME.format(identifier))
-    rotating_handler = RotatingFileHandler(logfile, maxBytes=FILE_SIZE, backupCount=10)
-    rotating_handler.setFormatter(formatter)
-    logger.addHandler(rotating_handler)
+    filehandler = FileHandler(logfile)
+    filehandler.setFormatter(formatter)
+    logger.addHandler(filehandler)
 
     stats_logger = logging.getLogger('stats')
     stats_formatter = CustomJsonFormatter(stats_logformat)
     stats_logfile = os.path.join(LOGS_DIR, 'vyked_stats.log')
-    stats_handler = RotatingFileHandler(stats_logfile, maxBytes=1024 * 1024, backupCount=5)
+    stats_handler = FileHandler(stats_logfile)
     stats_handler.setLevel(logging.INFO)
     stats_handler.setFormatter(stats_formatter)
     stats_logger.addHandler(stats_handler)
-    stats_logger.addHandler(rotating_handler)
+    stats_logger.addHandler(filehandler)
     # Stats.periodic_stats_logger()
 
     registry_logger = logging.getLogger('vyked.registry')


### PR DESCRIPTION
When TCP Pinger has a timeout, it closes the connection to avoid wasting file-descriptors.
