### PR TITLE
Re-registration fix

### DIFF
--- a/vyked/packet.py
+++ b/vyked/packet.py
@@ -16,15 +16,21 @@ class _Packet:
         return {'pid': cls._next_pid(), 'type': 'ack', 'request_id': request_id}
 
     @classmethod
-    def pong(cls, node_id):
+    def pong(cls, node_id, payload=None):
+        if payload:
+            return cls._get_ping_pong(node_id, 'ping', payload=payload)
         return cls._get_ping_pong(node_id, 'pong')
 
     @classmethod
-    def ping(cls, node_id):
+    def ping(cls, node_id, payload=None):
+        if payload:
+            return cls._get_ping_pong(node_id, 'ping', payload=payload)
         return cls._get_ping_pong(node_id, 'ping')
 
     @classmethod
-    def _get_ping_pong(cls, node_id, packet_type):
+    def _get_ping_pong(cls, node_id, packet_type, payload=None):
+        if payload:
+            return {'pid': cls._next_pid(), 'type': packet_type, 'node_id': node_id, 'payload': payload}
         return {'pid': cls._next_pid(), 'type': packet_type, 'node_id': node_id}
 
 

--- a/vyked/pinger.py
+++ b/vyked/pinger.py
@@ -4,6 +4,7 @@ from aiohttp import request
 
 from vyked.packet import ControlPacket
 import logging
+import functools
 
 PING_TIMEOUT = 10
 PING_INTERVAL = 5
@@ -32,34 +33,34 @@ class Pinger:
         self._max_failures = max_failures
 
     @asyncio.coroutine
-    def send_ping(self):
+    def send_ping(self, payload=None):
         """
         Sends the ping after the interval specified when initializing
         """
         yield from asyncio.sleep(self._interval)
-        self._handler.send_ping()
-        self._start_timer()
+        self._handler.send_ping(payload=payload)
+        self._start_timer(payload=payload)
 
-    def pong_received(self):
+    def pong_received(self, payload=None):
         """
         Called when a pong is received. So the timer is cancelled
         """
         if self._timer is not None:
             self._timer.cancel()
             self._failures = 0
-            asyncio.async(self.send_ping())
+            asyncio.async(self.send_ping(payload=payload))
 
-    def _start_timer(self):
-        self._timer = self._loop.call_later(self._timeout, self._on_timeout)
+    def _start_timer(self, payload=None):
+        self._timer = self._loop.call_later(self._timeout, functools.partial(self._on_timeout, payload=payload))
 
     def stop(self):
         if self._timer is not None:
             self._timer.cancel()
 
-    def _on_timeout(self):
+    def _on_timeout(self, payload=None):
         if self._failures < self._max_failures:
             self._failures += 1
-            asyncio.async(self.send_ping())
+            asyncio.async(self.send_ping(payload=payload))
         else:
             self._handler.on_timeout()
 
@@ -75,11 +76,11 @@ class TCPPinger:
         self._protocol = protocol
         self._handler = handler
 
-    def ping(self):
-        asyncio.async(self._pinger.send_ping())
+    def ping(self, payload=None):
+        asyncio.async(self._pinger.send_ping(payload=payload))
 
-    def send_ping(self):
-        self._protocol.send(ControlPacket.ping(self._node_id))
+    def send_ping(self, payload=None):
+        self._protocol.send(ControlPacket.ping(self._node_id, payload=payload))
 
     def on_timeout(self):
         self.logger.debug('%s timed out', self._node_id)
@@ -92,8 +93,8 @@ class TCPPinger:
     def stop(self):
         self._pinger.stop()
 
-    def pong_received(self):
-        self._pinger.pong_received()
+    def pong_received(self, payload=None):
+        self._pinger.pong_received(payload=payload)
 
 
 class HTTPPinger:
@@ -107,16 +108,16 @@ class HTTPPinger:
         self._url = 'http://{}:{}/ping'.format(host, port)
         self.logger = logging.getLogger(__name__)
 
-    def ping(self):
-        asyncio.async(self._pinger.send_ping())
+    def ping(self, payload=None):
+        asyncio.async(self._pinger.send_ping(payload=payload))
 
-    def send_ping(self):
-        asyncio.async(self.ping_coroutine())
+    def send_ping(self, payload=None):
+        asyncio.async(self.ping_coroutine(payload=payload))
 
-    def ping_coroutine(self):
+    def ping_coroutine(self, payload=None):
         res = yield from request('get', self._url)
         if res.status == 200:
-            self.pong_received()
+            self.pong_received(payload=payload)
             res.close()
 
     def stop(self):
@@ -126,5 +127,5 @@ class HTTPPinger:
         self.logger.debug('%s timed out', self._node_id)
         self._handler.on_timeout(self._host, self._port, self._node_id)
 
-    def pong_received(self):
-        self._pinger.pong_received()
+    def pong_received(self, payload=None):
+        self._pinger.pong_received(payload=payload)

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -214,7 +214,17 @@ class Registry:
         elif request_type == 'get_subscribers':
             self.get_subscribers(packet, protocol)
         elif request_type == 'pong':
-            self._ping(packet)
+            if 'payload' in packet:
+                to_send=True
+                node_ids = list(packet['payload'].values())
+                for node_id in node_ids:
+                    if self._repository.get_node(node_id) is None:
+                        to_send = False
+                        break
+                if to_send:
+                    self._pong(packet, protocol)
+            else:
+                self._pong(packet, protocol)
         elif request_type == 'ping':
             self._pong(packet, protocol)
         elif request_type == 'uptime_report':

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -224,9 +224,9 @@ class Registry:
                         to_send = False
                         break
                 if to_send:
-                    self._ping(packet)
+                    self._pong(packet, protocol)
             else:
-                self._ping(packet)
+                self._pong(packet, protocol)
         elif request_type == 'uptime_report':
             self._get_uptime_report(packet, protocol)
 

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -222,9 +222,9 @@ class Registry:
                         to_send = False
                         break
                 if to_send:
-                    self._pong(packet, protocol)
+                    self._ping(packet)
             else:
-                self._pong(packet, protocol)
+                self._ping(packet)
         elif request_type == 'ping':
             self._pong(packet, protocol)
         elif request_type == 'uptime_report':

--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -214,6 +214,8 @@ class Registry:
         elif request_type == 'get_subscribers':
             self.get_subscribers(packet, protocol)
         elif request_type == 'pong':
+            self._ping(packet)
+        elif request_type == 'ping':
             if 'payload' in packet:
                 to_send=True
                 node_ids = list(packet['payload'].values())
@@ -225,8 +227,6 @@ class Registry:
                     self._ping(packet)
             else:
                 self._ping(packet)
-        elif request_type == 'ping':
-            self._pong(packet, protocol)
         elif request_type == 'uptime_report':
             self._get_uptime_report(packet, protocol)
 


### PR DESCRIPTION
Registry responds to pongs from registry clients only if all services handled by it are registered.

This ensures that active de-registered services eventually re-register.
