### PR TITLE
Instead of the specified one, use service's external ip address

### DIFF
--- a/vyked/registry.py
+++ b/vyked/registry.py
@@ -204,6 +204,7 @@ class Registry:
             for_log["request_type"] = request_type
             self.logger.debug(for_log)
         if request_type == 'register':
+            packet['params']['host'] = transport.get_extra_info("peername")[0]
             self.register_service(packet, protocol)
         elif request_type == 'get_instances':
             self.get_service_instances(packet, protocol)


### PR DESCRIPTION
So the address specified by the service might be 0.0.0.0 if it wants
to listen on all the network-interfaces on its host. But registry's
pinger can't connect to the service on 0.0.0.0. Hence the patch.
