### PR TITLE
Downgrading requests to 2.4.3 as the latest one corrupts pip.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,4 +13,4 @@ pytest==2.7.2
 factory-boy==2.5.2
 python-json-logger==0.1.2
 PyYAML==3.11
-requests==2.7.0
+requests==2.4.3


### PR DESCRIPTION
More on the matter is available at [1].

[1] http://stackoverflow.com/a/27341847/338691
