### PR TITLE
Added request_type 'services_report' to registry

### DIFF
--- a/vyked/packet.py
+++ b/vyked/packet.py
@@ -141,6 +141,13 @@ class ControlPacket(_Packet):
         return packet
 
     @classmethod
+    def services(cls, services):
+        packet = {'pid': cls._next_pid(),
+                  'type': 'services_report',
+                  'params': dict(services)}
+        return packet
+
+    @classmethod
     def new_instance(cls, name, version, host, port, node_id, service_type):
         params = {'name': name, 'version': version, 'host': host, 'port': port, 'node_id': node_id,
                   'service_type': service_type}


### PR DESCRIPTION
Fix for Issue #121 

Registry now returns all services on request_type=='services_report'. 

Format:
dict[service_name][service_version] = [list of (host, ip, node_id, type, {optional=is_pending})]

Note: 
If service_a depends on service_b, and service_b has not registered yet, then the return value would have dict[service_b][version] = []
