### PR TITLE
make host-ip appear consistently in log

### DIFF
--- a/vyked/utils/stats.py
+++ b/vyked/utils/stats.py
@@ -95,7 +95,7 @@ class Aggregator:
 
     @classmethod
     def periodic_aggregated_stats_logger(cls):
-        hostname = socket.gethostname()
+        hostname = socket.gethostbyname(socket.gethostname())
         service_name = '_'.join(setproctitle.getproctitle().split('_')[:-1])
 
         logd = cls._stats.to_dict()


### PR DESCRIPTION
logging `socket.hostname() was making the json inconsistent and raising alarms unreliable.
this should fix the situation.
