### PR TITLE
Ordered Class Member now returns inherited class methods correctly

### DIFF
--- a/vyked/utils/ordered_class_member.py
+++ b/vyked/utils/ordered_class_member.py
@@ -8,9 +8,9 @@ class OrderedClassMembers(type):
 
     def __new__(self, name, bases, classdict):
         classdict['__ordered__'] = [key for key in classdict.keys() if key not in ('__module__', '__qualname__')]
-        for each in bases: #add keys from base classes also
+        for each in bases:  # add keys from base classes also
             odict = getattr(each, '__ordered__', each.__dict__)
             classdict['__ordered__'] = [key for key in odict if key not in ('__module__', '__qualname__')] + \
-                                       classdict['__ordered__']
+                classdict['__ordered__']
 
         return type.__new__(self, name, bases, classdict)

--- a/vyked/utils/ordered_class_member.py
+++ b/vyked/utils/ordered_class_member.py
@@ -9,6 +9,8 @@ class OrderedClassMembers(type):
     def __new__(self, name, bases, classdict):
         classdict['__ordered__'] = [key for key in classdict.keys() if key not in ('__module__', '__qualname__')]
         for each in bases: #add keys from base classes also
-            classdict['__ordered__'] += [key for key in each.__dict__ if key not in ('__module__', '__qualname__')]
+            odict = getattr(each, '__ordered__', each.__dict__)
+            classdict['__ordered__'] = [key for key in odict if key not in ('__module__', '__qualname__')] + \
+                                       classdict['__ordered__']
 
         return type.__new__(self, name, bases, classdict)


### PR DESCRIPTION
This fix will allow services to write '@get(path='/{param}')' without overwriting ping or _stats.
