### PR TITLE
Issue 135 fix

### DIFF
--- a/vyked/bus.py
+++ b/vyked/bus.py
@@ -187,8 +187,6 @@ class TCPBus:
             self._handle_ping(packet, protocol)
         elif packet['type'] == 'pong':
             self._handle_pong(packet['node_id'], packet['count'])
-        elif packet['type'] == 'publish':
-            self._handle_publish(packet, protocol)
         else:
             if self.tcp_host.is_for_me(packet['name'], packet['version']):
                 func = getattr(self, '_' + packet['type'] + '_receiver')
@@ -210,15 +208,6 @@ class TCPBus:
             future.add_done_callback(send_result)
         else:
             print('no api found for packet: ', packet)
-
-    def _handle_publish(self, packet, protocol):
-        service, version, endpoint, payload, publish_id = (packet['name'], packet['version'], packet['endpoint'],
-                                                           packet['payload'], packet['publish_id'])
-        for client in self._service_clients:
-            if client.name == service and client.version == version:
-                fun = getattr(client, endpoint)
-                asyncio.async(fun(**payload))
-        protocol.send(MessagePacket.ack(publish_id))
 
     def handle_connected(self):
         if self.tcp_host:

--- a/vyked/bus.py
+++ b/vyked/bus.py
@@ -248,7 +248,6 @@ class PubSubBus:
         subs_list = []
         xsubs_list4registry = []
         xsubs_list4redis = []
-        node_id = self._registry_client._node_ids['tcp']
         for client in clients:
             if isinstance(client, TCPServiceClient):
                 for each in dir(client):
@@ -293,7 +292,7 @@ class PubSubBus:
 
     def subscription_handler(self, endpoint, payload):
         elements = endpoint.split('/')
-        if len(elements)>3:
+        if len(elements) > 3:
             service, version, endpoint, node_id = elements
         else:
             service, version, endpoint = elements


### PR DESCRIPTION
Publish is now handled by redis. Xsubscribers subscribe to events on the key: service_version_endpoint_(node_id).
