### PR TITLE
Shifted deprecated_api processing from jsonprotocol.py to services.py

### DIFF
--- a/vyked/jsonprotocol.py
+++ b/vyked/jsonprotocol.py
@@ -61,12 +61,6 @@ class JSONProtocol(asyncio.Protocol):
 
     def data_received(self, byte_data):
         string_data = byte_data.decode()
-        if '"old_api":' in string_data:
-            payload = json.loads(string_data[:-1])['payload']
-            warning = 'Deprecated API: ' + payload['old_api']
-            if 'replacement_api' in payload.keys():
-                warning += ', New API: ' + payload['replacement_api']
-            self.logger.warn(warning)
         self.logger.debug('Data received: %s', string_data)
         try:
             self._obj_streamer.consume(string_data)

--- a/vyked/services.py
+++ b/vyked/services.py
@@ -399,6 +399,11 @@ class TCPServiceClient(_Service):
         request_id = payload['request_id']
         has_result = 'result' in payload
         has_error = 'error' in payload
+        if 'old_api' in payload:
+            warning = 'Deprecated API: ' + payload['old_api']
+            if 'replacement_api' in payload:
+                warning += ', New API: ' + payload['replacement_api']
+            logging.getLogger().warn(warning)
         future = self._pending_requests.pop(request_id)
         if has_result:
             if not future.done() and not future.cancelled():


### PR DESCRIPTION
This will get rid off the string processing of every packet.
